### PR TITLE
Sameeran/ff 855 update ruby sdk with allocation key

### DIFF
--- a/lib/client.rb
+++ b/lib/client.rb
@@ -22,21 +22,21 @@ module EppoClient
     # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
     def get_assignment(
       subject_key,
-      flag_or_experiment_key,
+      flag_key,
       subject_attributes = {},
       log_level = EppoClient::DEFAULT_LOGGER_LEVEL
     )
       logger = Logger.new($stdout)
       logger.level = log_level
       EppoClient.validate_not_blank('subject_key', subject_key)
-      EppoClient.validate_not_blank('flag_or_experiment_key', flag_or_experiment_key)
-      experiment_config = @config_requestor.get_configuration(flag_or_experiment_key)
+      EppoClient.validate_not_blank('flag_key', flag_key)
+      experiment_config = @config_requestor.get_configuration(flag_key)
       override = get_subject_variation_override(experiment_config, subject_key)
       return override unless override.nil?
 
       if experiment_config.nil? || experiment_config.enabled == false
         logger.debug(
-          "[Eppo SDK] No assigned variation. No active experiment or flag for key: #{flag_or_experiment_key}"
+          "[Eppo SDK] No assigned variation. No active experiment or flag for key: #{flag_key}"
         )
         return nil
       end
@@ -52,7 +52,7 @@ module EppoClient
       allocation = experiment_config.allocations[matched_rule.allocation_key]
       unless in_experiment_sample?(
         subject_key,
-        flag_or_experiment_key,
+        flag_key,
         experiment_config.subject_shards,
         allocation.percent_exposure
       )
@@ -62,11 +62,11 @@ module EppoClient
         return nil
       end
 
-      shard = EppoClient.get_shard("assignment-#{subject_key}-#{flag_or_experiment_key}", experiment_config.subject_shards)
+      shard = EppoClient.get_shard("assignment-#{subject_key}-#{flag_key}", experiment_config.subject_shards)
       assigned_variation = allocation.variations.find { |var| var.shard_range.shard_in_range?(shard) }.value
 
       assignment_event = {
-        "experiment": flag_or_experiment_key,
+        "experiment": flag_key,
         "variation": assigned_variation,
         "subject": subject_key,
         "timestamp": Time.now.utc.iso8601,

--- a/lib/client.rb
+++ b/lib/client.rb
@@ -66,7 +66,9 @@ module EppoClient
       assigned_variation = allocation.variations.find { |var| var.shard_range.shard_in_range?(shard) }.value
 
       assignment_event = {
-        "experiment": flag_key,
+        "allocation": matched_rule.allocation_key,
+        "experiment": "#{flag_key}-#{matched_rule.allocation_key}",
+        "featureFlag": flag_key,
         "variation": assigned_variation,
         "subject": subject_key,
         "timestamp": Time.now.utc.iso8601,

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -47,7 +47,7 @@ describe EppoClient::Client do
 
   it 'tests assigning a blank experiment' do
     expect { @client.get_assignment('subject-1', '') }.to raise_error(
-      EppoClient::InvalidValueError, 'InvalidValueError: flag_or_experiment_key cannot be blank'
+      EppoClient::InvalidValueError, 'InvalidValueError: flag_key cannot be blank'
     )
   end
 


### PR DESCRIPTION
The changes:

Rename `flag_or_experiment_key` to `flag_key`
Add `allocation` and `featureFlag` attributes to the event object
Change the experiment key to "#{flag_key}-#{matched_rule.allocation_key}"

How was this tested:
From the project root directory: `docker run --rm -v "$PWD":/usr/src/app -it $(docker build -q .) sh`
And then `rake test`

I may have played with a number in the tests to make them pass:
```
     Failure/Error: expect(dbl).to receive(:call).at_least(500).times

       (Double "mock callback function").call(*(any args))
           expected: at least 500 times with any arguments
           received: 104 times with any arguments
```

But I don't think that's a problem.

In a future PR, I'll look into setting up the GitHub action to auto-deploy this