### PR TITLE
publish to ruby gems (FF-922)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,37 @@
+name: Ruby Gem
+
+on:
+  # Manually publish
+  workflow_dispatch:
+  # Alternatively, publish whenever changes are merged to the `main` branch.
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  publish:
+    name: Build + Publish
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Ruby 3.0
+      uses: ruby/setup-ruby@ec02537da5712d66d4d50a0f33b7eb52773b5ed1
+      with:
+        ruby-version: 3.0
+
+    - name: Install dependencies
+      run: bundle install
+
+    - name: Publish to RubyGems
+      run: |
+        mkdir -p $HOME/.gem
+        touch $HOME/.gem/credentials
+        chmod 0600 $HOME/.gem/credentials
+        printf -- "---\n:rubygems_api_key: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
+        gem build *.gemspec
+        gem push *.gem
+      env:
+        GEM_HOST_API_KEY: "${{ secrets.RUBYGEMS_AUTH_TOKEN }}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,13 +1,8 @@
 name: Ruby Gem
 
 on:
-  # Manually publish
-  workflow_dispatch:
-  # Alternatively, publish whenever changes are merged to the `main` branch.
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+  release:
+    types: [published]
 
 jobs:
   publish:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    eppo-server-sdk (0.2.0)
+    eppo-server-sdk (0.2.1)
       concurrent-ruby (~> 1.1, >= 1.1.9)
       faraday (~> 2.7, >= 2.7.1)
       faraday-retry (~> 2.0, >= 2.0.0)
@@ -13,15 +13,17 @@ GEM
     addressable (2.8.1)
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
-    concurrent-ruby (1.1.10)
+    base64 (0.1.1)
+    concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
     diff-lcs (1.5.0)
-    faraday (2.7.2)
+    faraday (2.7.11)
+      base64
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.2)
-    faraday-retry (2.0.0)
+    faraday-retry (2.2.0)
       faraday (~> 2.0)
     hashdiff (1.0.1)
     jaro_winkler (1.5.6)

--- a/eppo-server-sdk.gemspec
+++ b/eppo-server-sdk.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name        = 'eppo-server-sdk'
-  s.version     = '0.2.0'
+  s.version     = '0.2.1'
   s.summary     = 'Eppo SDK for Ruby'
   s.authors     = ['Eppo']
   s.email       = 'eppo-team@geteppo.com'

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -28,7 +28,7 @@ describe EppoClient::Client do
     stub_request(
       :get,
       "#{MOCK_BASE_URL}/randomized_assignment/v3/config?apiKey=dummy&sdkName="\
-      'ruby&sdkVersion=0.2.0'
+      'ruby&sdkVersion=0.2.1'
     ).to_return(
       body: File.read('spec/test-data/rac-experiments-v3.json')
     )


### PR DESCRIPTION
I had originally made this PR to automatically publish, which did publish version 0.2.1 - https://rubygems.org/gems/eppo-server-sdk/versions/0.2.1

## rollout plan

* yank version 0.2.1
* create a new github release
* this action will run