### PR TITLE
add support for targeting rule evaluation with semver

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,5 @@
 source 'http://rubygems.org'
 
 gemspec
+
+gem 'semver2', '~> 3.4', '>= 3.4.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    eppo-server-sdk (0.2.3)
+    eppo-server-sdk (0.2.4)
       concurrent-ruby (~> 1.1, >= 1.1.9)
       faraday (~> 2.7, >= 2.7.1)
       faraday-retry (~> 2.0, >= 2.0.0)
@@ -12,18 +12,20 @@ GEM
     addressable (2.8.1)
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
-    concurrent-ruby (1.1.10)
+    concurrent-ruby (1.2.3)
     crack (0.4.5)
       rexml
     diff-lcs (1.5.0)
-    faraday (2.7.2)
-      faraday-net_http (>= 2.0, < 3.1)
-      ruby2_keywords (>= 0.0.4)
-    faraday-net_http (3.0.2)
-    faraday-retry (2.0.0)
+    faraday (2.9.0)
+      faraday-net_http (>= 2.0, < 3.2)
+    faraday-net_http (3.1.0)
+      net-http
+    faraday-retry (2.2.0)
       faraday (~> 2.0)
     hashdiff (1.0.1)
     jaro_winkler (1.5.6)
+    net-http (0.4.1)
+      uri
     parallel (1.22.1)
     parser (3.2.0.0)
       ast (~> 2.4.1)
@@ -53,8 +55,9 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 2.0)
     ruby-progressbar (1.11.0)
-    ruby2_keywords (0.0.5)
+    semver2 (3.4.2)
     unicode-display_width (1.8.0)
+    uri (0.13.0)
     webmock (3.18.1)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -69,6 +72,7 @@ DEPENDENCIES
   rake (~> 13.0, >= 13.0.6)
   rspec (~> 3.12, >= 3.12.0)
   rubocop (~> 0.82.0)
+  semver2 (~> 3.4, >= 3.4.2)
   webmock (~> 3.18, >= 3.18.1)
 
 BUNDLED WITH

--- a/lib/eppo_client/version.rb
+++ b/lib/eppo_client/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module EppoClient
-  VERSION = '0.2.3'
+  VERSION = '0.2.4'
 end


### PR DESCRIPTION
## Motivation and Context

Eppo's RAC API will start returning targeting rule values containing semver strings. Our SDKs need to be able to parse these strings and perform rule evaluation on them. This change in rule logic has already been applied to a few other SDKs: 

https://github.com/Eppo-exp/python-sdk/pull/27
https://github.com/Eppo-exp/js-client-sdk-common/pull/38
https://github.com/Eppo-exp/eppo-ios-sdk/pull/10

## Description

The operations `lt`, `gt`, `lte`, `gte` apply to both numeric values and semver strings. Previously it was only numeric values.

## Behavior of un-upgraded SDKs

They will continue to assume that only numeric values will be present for the `lt`, `gt`, `lte`, `gte` operations.