### PR TITLE
bug: [reset configuration cache when updating] (FF-2495)

### DIFF
--- a/lib/eppo_client/configuration_store.rb
+++ b/lib/eppo_client/configuration_store.rb
@@ -20,9 +20,15 @@ module EppoClient
 
     def assign_configurations(configs)
       @lock.with_write_lock do
+        # Create a temporary new cache and populate it.
+        new_cache = EppoClient::LRUCache.new(@cache.size)
         configs.each do |key, config|
-          @cache[key] = config
+          new_cache[key] = config
         end
+
+        # Replace the old cache with the new one.
+        # Performs an atomic swap.
+        @cache = new_cache
       end
     end
   end

--- a/lib/eppo_client/lru_cache.rb
+++ b/lib/eppo_client/lru_cache.rb
@@ -5,7 +5,7 @@ module EppoClient
   # and re-inserting a key-value pair on access moves the key to the last position. When an
   # entry is added and the cache is full, the first entry is removed.
   class LRUCache
-    attr_reader :cache
+    attr_reader :cache, :size
 
     # Creates a new LRUCache that can hold +size+ entries.
     def initialize(size)

--- a/lib/eppo_client/version.rb
+++ b/lib/eppo_client/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module EppoClient
-  VERSION = '0.2.4'
+  VERSION = '0.2.5'
 end

--- a/spec/configuration_store_spec.rb
+++ b/spec/configuration_store_spec.rb
@@ -36,4 +36,15 @@ describe EppoClient::ConfigurationStore do
     expect(store.retrieve_configuration('item_to_be_evicted')).to be_nil
     expect(store.retrieve_configuration("test-entry-#{TEST_MAX_SIZE - 1}")).to be(test_exp)
   end
+
+  it 'uses the incoming configurations as the source of truth' do
+    store.assign_configurations({ 'item1' => test_exp, 'item2' => test_exp })
+
+    expect(store.retrieve_configuration('item1')).to be(test_exp)
+    expect(store.retrieve_configuration('item2')).to be(test_exp)
+
+    store.assign_configurations({ 'item1' => test_exp })
+    expect(store.retrieve_configuration('item1')).to be(test_exp)
+    expect(store.retrieve_configuration('item2')).to be_nil
+  end
 end


### PR DESCRIPTION
When setting the configuration cache, create a new instance and populate it. Perform an atomic swap so that assignments continue to be served without interruption.

## Notes to reviewers

There is failing tests on macos environment - these are unrelated to the changes.